### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/upx`
 
-The Paketo UPX Buildpack is a Cloud Native Buildpack that providex UPX a tool that can be used to compress executables.
+The Paketo Buildpack for UPX is a Cloud Native Buildpack that providex UPX a tool that can be used to compress executables.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/upx"
   id = "paketo-buildpacks/upx"
   keywords = ["upx", "compression"]
-  name = "Paketo UPX Buildpack"
+  name = "Paketo Buildpack for UPX"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo UPX Buildpack' to 'Paketo Buildpack for UPX'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
